### PR TITLE
Bump colcon-core minimum version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ keywords = colcon
 
 [options]
 install_requires =
-  colcon-core>=0.7.1
+  colcon-core>=0.8.0
   colcon-installed-package-information
 packages = find:
 zip_safe = true

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-override-check]
 No-Python2:
-Depends3: python3-colcon-core (>= 0.7.1), python3-colcon-installed-package-information
+Depends3: python3-colcon-core (>= 0.8.0), python3-colcon-installed-package-information
 Suite: bionic focal jammy stretch buster bullseye
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
Despite requiring version colcon-core 0.7.1 from an API perspective, this extensions conflicts with some of the code present in all 0.7.x releases. Instead of conflicting with 0.7.x, it's easier to just bump the requirement to 0.8.x.

FYI @chapulina

Should prevent osrf/buoy_entrypoint#2 from being possible